### PR TITLE
Fix accordion css

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -28,6 +28,7 @@
 .btn-link {
   color: black;
   font-style: italic;
+  background-color: $light-gray;
 }
 // expanded card body (where the cards will show)
 .card-body {
@@ -39,3 +40,15 @@
   font-style: normal;
   font-weight: bold;
 }
+
+// give each heading a bottom border for style
+#buttonOne {
+  border-bottom: 1px solid black;
+}
+#buttonTwo {
+  border-bottom: 1px solid black;
+}
+#buttonThree {
+  border-bottom: 1px solid black;
+}
+

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -33,7 +33,12 @@
 // expanded card body (where the cards will show)
 .card-body {
   background-color: $light-gray;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
+  padding-top: 16px;
 }
+
 // change the style of the accordion header when the menu is open
 // doesn't seem to work when I nest it in .btn-link
 .btn-link[aria-expanded="true"] {

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -8,7 +8,7 @@
 // accordion header card (all but last)
 // adding a darker border to mark the individual sections
 .accordion > .card:not(:last-of-type) {
-  border-bottom: 1px solid $gray; // originally not there
+  border: none;
 }
 // accordion header card
 // removing the box border

--- a/app/assets/stylesheets/pages/_group-show.scss
+++ b/app/assets/stylesheets/pages/_group-show.scss
@@ -1,6 +1,6 @@
 .group-name-banner{
   width: 100%;
-  height: 25vh;
+  min-height: 25vh;
   // margin-bottom: 24px;
   background-size: cover;
   background-position: center;

--- a/app/views/payment_groups/_accordion.html.erb
+++ b/app/views/payment_groups/_accordion.html.erb
@@ -3,10 +3,10 @@
 <div class="accordion" id="accordionExample">
   <!--   CARD DISPLAYING THE BOX AROUND THE BUTTON TO EXPAND THE ACCORDION -->
   <div class="card">
-    <div class="card-header" id="headingOne">
+    <div class="" id="headingOne">
       <h2 class="mb-0">
         <!-- TEXT OF BUTTON FOR THE ACCORDION MENU OPTION -->
-        <button class="btn btn-link btn-block" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+        <button class="btn btn-link btn-block" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne" id="buttonOne">
           Active Splits
         </button>
       </h2>
@@ -22,10 +22,10 @@
   </div>
   <!--   CARD DISPLAYING THE BOX AROUND THE BUTTON TO EXPAND THE ACCORDION -->
   <div class="card">
-    <div class="card-header" id="headingTwo">
+    <div class="" id="headingTwo">
       <h2 class="mb-0">
         <!-- TEXT OF BUTTON FOR THE ACCORDION MENU OPTION -->
-        <button class="btn btn-link btn-block collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+        <button class="btn btn-link btn-block collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo" id="buttonTwo">
           Archived Splits
         </button>
       </h2>
@@ -41,10 +41,10 @@
   </div>
   <!--   CARD DISPLAYING THE BOX AROUND THE BUTTON TO EXPAND THE ACCORDION -->
   <div class="card">
-    <div class="card-header" id="headingThree">
+    <div class="" id="headingThree">
       <h2 class="mb-0">
         <!-- TEXT OF BUTTON FOR THE ACCORDION MENU OPTION -->
-        <button class="btn btn-link btn-block collapsed" type="button" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+        <button class="btn btn-link btn-block collapsed" type="button" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree" id="buttonThree">
           Members
         </button>
       </h2>
@@ -60,10 +60,10 @@
   </div>
   <!--   CARD DISPLAYING THE BOX AROUND THE BUTTON TO EXPAND THE ACCORDION -->
   <div class="card">
-    <div class="card-header" id="headingFour">
+    <div class="" id="headingFour">
       <h2 class="mb-0">
         <!-- TEXT OF BUTTON FOR THE ACCORDION MENU OPTION -->
-        <button class="btn btn-link btn-block collapsed" type="button" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+        <button class="btn btn-link btn-block collapsed" type="button" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour" id="buttonFour">
           New Split
         </button>
       </h2>


### PR DESCRIPTION
Removed the side padding on the .card-body to make the cards a bit bigger for readability.

Also changed the 'height: 25vh' to 'max-height: 25vh' to stop the banner image from shrinking when there are a lot of cards to display.

Finally, removed the gray lines caused by bootstrap.

<img width="310" alt="Screen Shot 2021-06-03 at 16 57 52" src="https://user-images.githubusercontent.com/55191871/120609308-0350ec80-c48d-11eb-84c2-8fe01f702dcf.png">
