### PR TITLE
fixed splash page logic

### DIFF
--- a/app/views/pages/splash.html.erb
+++ b/app/views/pages/splash.html.erb
@@ -3,8 +3,14 @@
     <h3>Dealing with shared expenses is difficult.</h3><br><br>
     <h5>Luckily, we're here for you.</h5>
   </div>
+  <% if signed_in? %>
+  <div class="splash-buttons">
+    <%= link_to 'Home', home_path, class: 'btn button' %>
+  </div>
+  <% else %>
   <div class="splash-buttons">
     <%= link_to 'Sign Up', new_user_registration_path, class: 'btn button' %> &nbsp;<h3 style="color: black;">or</h3> &nbsp;
     <%= link_to 'Sign In', user_session_path, class: 'btn button' %>
   </div>
+  <% end %>
 </div>


### PR DESCRIPTION
If you're signed out, it displays the sign up and sign in buttons
<img width="360" alt="Screen Shot 2021-06-10 at 11 48 39" src="https://user-images.githubusercontent.com/55191871/121456987-e6af3a00-c9e1-11eb-919e-1ce0d94aef5d.png">

if you're signed in, it displays the home button
<img width="339" alt="Screen Shot 2021-06-10 at 11 48 52" src="https://user-images.githubusercontent.com/55191871/121457004-edd64800-c9e1-11eb-890f-a9680d4daf58.png">
